### PR TITLE
API suggestion

### DIFF
--- a/dstrf/__init__.py
+++ b/dstrf/__init__.py
@@ -1,4 +1,4 @@
 from ._model import DstRF, REG_Data, gaussian_basis
 from ._fastac import Fasta
 from . import dsyevh3C
-from ._data_loader import *
+from ._data_loader import load_subject

--- a/dstrf/_crossvalidation.py
+++ b/dstrf/_crossvalidation.py
@@ -41,7 +41,7 @@ def mp_worker(fun, shared_job_q, shared_result_q, nprocs):
     shared_result_q.put(None)
 
 
-def crossvalidate(model, data, mus=None, n_splits=None, n_workers=None):
+def crossvalidate(model, mus=None, n_splits=None, n_workers=None):
     """used to perform cross-validation of cTRF model
 
     This function assumes `model` class has method _get_cvfunc(data, n_splits)
@@ -54,9 +54,6 @@ def crossvalidate(model, data, mus=None, n_splits=None, n_workers=None):
         model: object
             the model to be validated, here DstRF. In addition to that it needs to
             support `copy.copy` function.
-        data: object
-            the instance should be compatible for fitting the model. In addition to
-            that it shall have a timeslice method compatible to kfold objects.
         mus: list | ndarray  (floats)
             The range of the regularizing weights. If None, it will use values
             specified in config.py.

--- a/dstrf/_data_loader.py
+++ b/dstrf/_data_loader.py
@@ -3,7 +3,7 @@ from . import config as cfg
 
 import pickle
 import numpy as np
-from scipy import io, linalg
+from scipy import linalg
 
 from eelbrain import *
 


### PR DESCRIPTION
So this is mostly just a suggestion on how to structure the API. I added general instructions to the `DstRF` docstring.

I realized that adding the data to the  `DstRF` object as `DstRF._data` property will interfere with the way you used `DstRF.copy()` in `,fit()`, so that would have to be restructured... is that feasible? An alternative might be to hide the current `DstRF` object and construct a higher order object with the simplified API.

Also about the fit, I wonder whether it makes sense to keep the user-specified cross-validation parameters in the `.fit()` method or whether they should be moved to `.__init__()`? Do you think there will be use cases for fitting the same object with different parameters?

---

Or let's think about it this way: if I have the following variables:

```python
lead_field
covariance
meg  # NDVar  (case, sensor, time), where case reflects different trials
stim1  # NDVar  (case, time)  (e.g. envelope)
stim2  # NDVar  (case, scalar, time)  (e.g. spectrogram with multiple bands)
```
And:
 - I want the TRF to be 05 s long.

What would be the easiest way to fit the TRFs? 

# Function

What about a single function, that returns some result object that contains all relevant result properties?
```python
result = dstrf(meg, [stim1, stim2], lead_field, covariance, tstart=0, tstop=0.5)
```
That would be parallel to how boosting currently works. You could add a parameter for `mu` that can be a list or a scalar to do (or not) cross-validation. For data that is not equal length, the data arguments could be lists, i.e.

```python
result = dstrf([meg_1, meg_2], [[stim1_1, stim1_2], [stim2_1, stim2_2]], ...)
```

# Object

Alternatively, the object-based API:

```python
dstrf = DstRF(lead_field, covariance)
dstrf.add_data(meg, [stim1, stim2)
result = dstrf.fit()
```