### PR TITLE
RF:  use CVResult to store cross-validation results

### DIFF
--- a/dstrf/_crossvalidation.py
+++ b/dstrf/_crossvalidation.py
@@ -1,14 +1,23 @@
 import os
-import time
-import warnings
-from multiprocessing import Process, Queue, current_process
-import queue
 from math import ceil
+from multiprocessing import Process, Queue
+import queue
+from typing import List
 
 from eelbrain._config import CONFIG
 import numpy as np
 from scipy import signal
 from tqdm import tqdm
+
+
+class CVResult:
+
+    def __init__(self, mu, cv, es, cv1, cv2):
+        self.mu = mu
+        self.cv = cv
+        self.es = 10 if np.isnan(es) else es  # replace Nan values with a big number
+        self.cv1 = cv1
+        self.cv2 = cv2
 
 
 def naive_worker(fun, job_q, result_q):
@@ -21,15 +30,14 @@ def naive_worker(fun, job_q, result_q):
             job = job_q.get_nowait()
             # print('%s got %s mus...' % (myname, len(job)))
             for mu in job:
-                outdict = {mu: fun(mu)}
-                result_q.put(outdict)
+                result_q.put(fun(mu))
             # print('%s done' % myname)
         except queue.Empty:
             # print('returning from %s process' % myname)
             return
 
 
-def mp_worker(fun, shared_job_q, shared_result_q, nprocs):
+def start_workers(fun, shared_job_q, shared_result_q, nprocs):
     """sets up workers"""
     procs = []
     for i in range(nprocs):
@@ -38,54 +46,10 @@ def mp_worker(fun, shared_job_q, shared_result_q, nprocs):
             args=(fun, shared_job_q, shared_result_q))
         procs.append(p)
         p.start()
-
-    for p in procs:
-        p.join()
-
-    time.sleep(0.1)
-    shared_result_q.put(None)
+    return procs
 
 
-class collect_output(Process):
-    def __init__(self, N, result_q):
-        Process.__init__(self)
-        self.N = N
-        self.result_q = result_q
-
-    def run(self):
-        prog = tqdm(total=self.N, desc="Crossvalidation", unit='mu', unit_scale=True)
-        numresults = 0
-        resultdict = {}
-        n_attempts = 0
-        while True:
-            try:
-                outdict = self.result_q.get(False)  # no wait
-                if outdict is None:
-                    prog.close()
-                    break
-                resultdict.update(outdict)
-                prog.update(n=len(outdict))
-                time.sleep(0.01)
-                numresults = len(resultdict)
-            except queue.Empty:
-                time.sleep(10)
-                prog.update(n=0)
-            except EOFError:
-                print('Opps! EOFError encountered.')
-                n_attempts += 1
-                print('Retrying %i th time' % n_attempts)
-                if n_attempts > 100:
-                    break
-
-        if numresults < self.N:
-            warnings.warn('%i objects are missing' % (self.N - numresults), )
-
-        self.result_q.put(format_to_array(resultdict))
-        time.sleep(0.1)
-        return
-
-
-def crossvalidate(model, data, mus, n_splits, n_workers=None, ):
+def crossvalidate(model, data, mus, n_splits, n_workers=None) -> List[CVResult]:
     """used to perform cross-validation of cTRF model
 
     This function assumes `model` class has method _get_cvfunc(data, n_splits)
@@ -114,6 +78,7 @@ def crossvalidate(model, data, mus, n_splits, n_workers=None, ):
     cv_info : ndarray
         Contains evaluated cross-validation metrics for ``mus``.
     """
+    prog = tqdm(total=len(mus), desc="Crossvalidation", unit='mu', unit_scale=True)
     if n_workers is None:
         n = CONFIG['n_workers'] or 1  # by default this is cpu_count()
         n_workers = ceil(n / 8)
@@ -126,72 +91,18 @@ def crossvalidate(model, data, mus, n_splits, n_workers=None, ):
     for mu in mus:
         job_q.put([mu])  # put the job as a list.
 
-    prog = collect_output(len(mus), result_q)
-    prog.start()
-    mp_worker(fun, job_q, result_q, n_workers)
-    prog.join()
+    workers = start_workers(fun, job_q, result_q, n_workers)
 
-    cvmu, esmu, cv_info = result_q.get()
+    results = []
+    for _ in range(len(mus)):
+        result = result_q.get()
+        results.append(result)
+        prog.update(n=len(results))
 
-    if cv_info[-1] is not None:
-        warnings.warn(cv_info[-1])
-    print('Building cross-validated model with mu %f' % cvmu)
-    return cvmu, esmu, cv_info
+    for worker in workers:
+        worker.join()
 
-
-def format_to_array(resultdict):
-    """format crossvalidation info dict to np.array"""
-    mu = []
-    cv = []
-    cv1 = []
-    cv2 = []
-    es = []
-    for keys, values in resultdict.items():
-        mu.append(keys)
-        cv.append(values['cv'])
-        cv1.append(values['cv1'])
-        cv2.append(values['cv2'])
-        es.append(values['es'])
-
-    mu = np.array(mu)
-    cv = np.array(cv)
-    cv1 = np.array(cv1)
-    cv2 = np.array(cv2)
-    es = np.array(es)
-
-    idx = np.argsort(np.array(mu))
-
-    mu = mu[idx]
-    cv = cv[idx]
-    cv1 = cv1[idx]
-    cv2 = cv2[idx]
-    es = es[idx]
-
-    Warn = None
-    # take care of nan values
-    es[np.isnan(es)] = 10  # replace Nan values by some big number (say 10)
-    # CVmu = mu[cv2.argmin()]
-    CVmu = mu[cv1.argmin()]
-    # ESmu = mu[cv2.argmin():][es[cv2.argmin():].argmin()]
-    # ESmu = mu[cv2.argmin() + signal.find_peaks(-es[cv2.argmin():])[0][0]]
-    if CVmu == mu[-1]:
-        ESmu = CVmu
-        Warn = f'CVmu is {CVmu}: extend range of mu towards right'
-    else:
-        try:
-            ESmu = mu[cv1.argmin() + signal.find_peaks(-es[cv1.argmin():])[0][0]]
-        except IndexError:
-            ESmu = CVmu
-            Warn = f'ESmu is {ESmu}: extend range of mu towards right'
-        if ESmu == mu[-1]:
-            Warn = f'ESmu is {ESmu}: extend range of mu towards right'
-    if CVmu == mu[0]:
-        if Warn is None:
-            Warn = f'CVmu is {CVmu}: extend range of mu towards left'
-        else:
-            Warn = f'{Warn}; CVmu is {CVmu}: extend range of mu towards left'
-
-    return CVmu, ESmu, (np.array([mu, cv, cv1, cv2, es]), Warn)
+    return results
 
 
 class TimeSeriesSplit:

--- a/dstrf/_model.py
+++ b/dstrf/_model.py
@@ -663,6 +663,8 @@ class DstRF:
         ..[1] Lim, Chinghway, and Bin Yu. "Estimation stability with cross-validation (ESCV)."
         Journal of Computational and Graphical Statistics 25.2 (2016): 464-492.
         """
+        if use_ES:
+            raise NotImplementedError
         # pre-whiten the object itself
         logger = logging.getLogger(__name__)
         if self._whitening_filter is None:
@@ -691,11 +693,8 @@ class DstRF:
                 cv_results.extend(crossvalidate(self, data, new_mus, n_splits, n_workers))
 
             self._cv_results = cv_results
-
-            if use_ES:
-                mu = esmu
-            else:
-                mu = cvmu
+            best_cv = min(cv_results, key=attrgetter('cv1'))
+            mu = best_cv.mu
         else:
             # use the passed mu
             if mu is None:


### PR DESCRIPTION
Illustrating what I meant with my suggestion to replace the CV output with a simple object to hold the results (`CVResult`). I could get rid of 100 extra lines of code. Rather than indexing and complex sorting the subsequent evaluation can then use meaningful labels (it could be made even clearer by replacing `cv`, `cv1` and `cv2` with more meaningful names). I skipped some of the `ESmu` evaluation which was unused.